### PR TITLE
Initialize Inksentials React Native skeleton

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+
+import ForumScreen from './src/screens/ForumScreen';
+import SocialScreen from './src/screens/SocialScreen';
+import ShopScreen from './src/screens/ShopScreen';
+import MembershipScreen from './src/screens/MembershipScreen';
+import PodcastScreen from './src/screens/PodcastScreen';
+import GalleryScreen from './src/screens/GalleryScreen';
+import AdminScreen from './src/screens/AdminScreen';
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Forum" component={ForumScreen} />
+        <Tab.Screen name="Social" component={SocialScreen} />
+        <Tab.Screen name="Shop" component={ShopScreen} />
+        <Tab.Screen name="Membership" component={MembershipScreen} />
+        <Tab.Screen name="Podcast" component={PodcastScreen} />
+        <Tab.Screen name="Gallery" component={GalleryScreen} />
+        <Tab.Screen name="Admin" component={AdminScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# inksentials-tattoo-app
+# Inksentials Tattoo App
+
+This repository contains a minimal React Native skeleton for the **Inksentials** mobile application. The project is designed to be expanded with features like forum discussions, social media feeds, a shop and marketplace, membership subscriptions, podcast streaming, an art gallery, and an admin dashboard.
+
+## Getting Started
+
+Install dependencies (requires Node and npm):
+
+```bash
+npm install
+```
+
+Run the Expo development server:
+
+```bash
+npm start
+```
+
+The current implementation provides placeholder screens for each major section. Use this as a starting point to build out the full feature set.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "inksentials",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "react-native-web": "^0.19.0",
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/bottom-tabs": "^6.5.20"
+  }
+}

--- a/src/screens/AdminScreen.js
+++ b/src/screens/AdminScreen.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function AdminScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Admin Dashboard</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});

--- a/src/screens/ForumScreen.js
+++ b/src/screens/ForumScreen.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ForumScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Forum / Community Section</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});

--- a/src/screens/GalleryScreen.js
+++ b/src/screens/GalleryScreen.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function GalleryScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Art Gallery</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function MembershipScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Membership Page</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});

--- a/src/screens/PodcastScreen.js
+++ b/src/screens/PodcastScreen.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function PodcastScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Podcast Section</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});

--- a/src/screens/ShopScreen.js
+++ b/src/screens/ShopScreen.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ShopScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Shop & Marketplace</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});

--- a/src/screens/SocialScreen.js
+++ b/src/screens/SocialScreen.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SocialScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Social Media Feed</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -1,0 +1,7 @@
+export { default as ForumScreen } from './ForumScreen';
+export { default as SocialScreen } from './SocialScreen';
+export { default as ShopScreen } from './ShopScreen';
+export { default as MembershipScreen } from './MembershipScreen';
+export { default as PodcastScreen } from './PodcastScreen';
+export { default as GalleryScreen } from './GalleryScreen';
+export { default as AdminScreen } from './AdminScreen';


### PR DESCRIPTION
## Summary
- add Expo style package.json and placeholder app screens
- implement navigation skeleton in `App.js`
- update README with minimal setup instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6876b7b0be10832f9e67b2830c13dafb